### PR TITLE
Feat/expression evaluator

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1,8 +1,16 @@
 package quang
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
+// TODO: eval expressions between float|integer and float|integer
 func evaluateExpression(expr *expression_t) (bool, error) {
+	if expr == nil {
+		return false, nil
+	}
+
 	switch expr.kind {
 	case ek_binary:
 		{
@@ -11,7 +19,7 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 			right := expr.binary.right
 
 			switch op {
-			case bo_eq, bo_ne, bo_gt, bo_lt, bo_gte, bo_lte:
+			case bo_eq, bo_ne, bo_gt, bo_lt, bo_gte, bo_lte, bo_reg:
 				{
 					if left.kind == ek_integer && right.kind == ek_integer {
 						return cmpIntegerToInteger(left.integer, op, right.integer)
@@ -21,7 +29,11 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 						return cmpFloatToFloat(left.float, op, right.float)
 					}
 
-					return false, fmt.Errorf("cannot equalize types %s and %s", ek_to_string[left.kind], ek_to_string[right.kind])
+					if left.kind == ek_string && right.kind == ek_string {
+						return cmpStringToString(left.string, op, right.string)
+					}
+
+					return false, fmt.Errorf("you cannot do such operation '%s %s %s'", ek_to_string[left.kind], bo_to_string[op], ek_to_string[right.kind])
 				}
 			case bo_or:
 				{
@@ -63,7 +75,7 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("error: could not parse such expression")
+	return false, fmt.Errorf("error: could not parse expression kind %s", ek_to_string[expr.kind])
 }
 
 func cmpIntegerToInteger(left int64, op binary_operator_t, right int64) (bool, error) {
@@ -82,7 +94,7 @@ func cmpIntegerToInteger(left int64, op binary_operator_t, right int64) (bool, e
 		return left <= right, nil
 	}
 
-	return false, fmt.Errorf("comparison operator not implemented yet")
+	return false, fmt.Errorf("you cannot do such operation 'integer %s integer'", bo_to_string[op])
 }
 
 func cmpFloatToFloat(left float64, op binary_operator_t, right float64) (bool, error) {
@@ -101,5 +113,28 @@ func cmpFloatToFloat(left float64, op binary_operator_t, right float64) (bool, e
 		return left <= right, nil
 	}
 
-	return false, fmt.Errorf("comparison operator not implemented yet")
+	return false, fmt.Errorf("you cannot do such operation 'float %s float'", bo_to_string[op])
+}
+
+func cmpStringToString(left string, op binary_operator_t, right string) (bool, error) {
+	switch op {
+	case bo_eq:
+		return left == right, nil
+	case bo_ne:
+		return left != right, nil
+	case bo_gt:
+		return left > right, nil
+	case bo_lt:
+		return left < right, nil
+	case bo_gte:
+		return left >= right, nil
+	case bo_lte:
+		return left <= right, nil
+	case bo_reg:
+		regex := regexp.MustCompile(right)
+
+		return regex.MatchString(left), nil
+	}
+
+	return false, fmt.Errorf("you cannot do such operation 'string %s string'", bo_to_string[op])
 }

--- a/eval.go
+++ b/eval.go
@@ -5,8 +5,88 @@ import (
 	"regexp"
 )
 
+type evaluator_t struct {
+	symbols    map[string]variable_t
+	expression *expression_t
+}
+
+func createEvaluator(expression *expression_t) evaluator_t {
+	return evaluator_t{
+		symbols:    make(map[string]variable_t),
+		expression: expression,
+	}
+}
+
+func (e *evaluator_t) addStringVar(name, value string) {
+	e.symbols[name] = variable_t{
+		dtype:  dtype_string,
+		string: value,
+	}
+}
+
+func (e *evaluator_t) addIntegerVar(name string, value integer_t) {
+	e.symbols[name] = variable_t{
+		dtype:   dtype_integer,
+		integer: value,
+	}
+}
+
+func (e *evaluator_t) addFloatVar(name string, value float_t) {
+	e.symbols[name] = variable_t{
+		dtype: dtype_float,
+		float: value,
+	}
+}
+
+func (e *evaluator_t) addBoolVar(name string, value bool) {
+	e.symbols[name] = variable_t{
+		dtype: dtype_bool,
+		bool:  value,
+	}
+}
+
+func (e *evaluator_t) lazyEvalVar(expr *expression_t) (*expression_t, error) {
+	if expr.kind == ek_lazy_symbol {
+		if variable, ok := e.symbols[expr.symbolName]; ok {
+			switch variable.dtype {
+			case dtype_string:
+				return &expression_t{
+					kind:   ek_string,
+					string: variable.string,
+				}, nil
+			case dtype_integer:
+				return &expression_t{
+					kind:    ek_integer,
+					integer: variable.integer,
+				}, nil
+			case dtype_float:
+				return &expression_t{
+					kind:  ek_float,
+					float: variable.float,
+				}, nil
+			case dtype_bool:
+				return &expression_t{
+					kind: ek_bool,
+					bool: variable.bool,
+				}, nil
+			case dtype_atom:
+				return &expression_t{
+					kind: ek_atom,
+					atom: variable.atom,
+				}, nil
+			default:
+				return nil, fmt.Errorf("error: could not lazy evaluate type %s", dtype_to_string[variable.dtype])
+			}
+		} else {
+			return nil, fmt.Errorf("error: the variable '%s' does not exist", expr.symbolName)
+		}
+	}
+
+	return expr, nil
+}
+
 // TODO: eval expressions between float|integer and float|integer
-func evaluateExpression(expr *expression_t) (bool, error) {
+func (e *evaluator_t) evaluateExpression(expr *expression_t) (bool, error) {
 	if expr == nil {
 		return false, nil
 	}
@@ -15,8 +95,17 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 	case ek_binary:
 		{
 			op := expr.binary.operator
-			left := expr.binary.left
-			right := expr.binary.right
+			left, err := e.lazyEvalVar(expr.binary.left)
+
+			if err != nil {
+				return false, err
+			}
+
+			right, err := e.lazyEvalVar(expr.binary.right)
+
+			if err != nil {
+				return false, err
+			}
 
 			switch op {
 			case bo_eq, bo_ne, bo_gt, bo_lt, bo_gte, bo_lte, bo_reg:
@@ -37,13 +126,13 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 				}
 			case bo_or:
 				{
-					leftValue, err := evaluateExpression(left)
+					leftValue, err := e.evaluateExpression(left)
 
 					if err != nil {
 						return false, err
 					}
 
-					rightValue, err := evaluateExpression(right)
+					rightValue, err := e.evaluateExpression(right)
 
 					if err != nil {
 						return false, err
@@ -53,13 +142,13 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 				}
 			case bo_and:
 				{
-					leftValue, err := evaluateExpression(left)
+					leftValue, err := e.evaluateExpression(left)
 
 					if err != nil {
 						return false, err
 					}
 
-					rightValue, err := evaluateExpression(right)
+					rightValue, err := e.evaluateExpression(right)
 
 					if err != nil {
 						return false, err
@@ -78,7 +167,11 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 	return false, fmt.Errorf("error: could not parse expression kind %s", ek_to_string[expr.kind])
 }
 
-func cmpIntegerToInteger(left int64, op binary_operator_t, right int64) (bool, error) {
+func (e *evaluator_t) eval() (bool, error) {
+	return e.evaluateExpression(e.expression)
+}
+
+func cmpIntegerToInteger(left integer_t, op binary_operator_t, right integer_t) (bool, error) {
 	switch op {
 	case bo_eq:
 		return left == right, nil
@@ -97,7 +190,7 @@ func cmpIntegerToInteger(left int64, op binary_operator_t, right int64) (bool, e
 	return false, fmt.Errorf("you cannot do such operation 'integer %s integer'", bo_to_string[op])
 }
 
-func cmpFloatToFloat(left float64, op binary_operator_t, right float64) (bool, error) {
+func cmpFloatToFloat(left float_t, op binary_operator_t, right float_t) (bool, error) {
 	switch op {
 	case bo_eq:
 		return left == right, nil

--- a/eval.go
+++ b/eval.go
@@ -17,6 +17,10 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 						return cmpIntegerToInteger(left.integer, op, right.integer)
 					}
 
+					if left.kind == ek_float && right.kind == ek_float {
+						return cmpFloatToFloat(left.float, op, right.float)
+					}
+
 					return false, fmt.Errorf("cannot equalize types %s and %s", ek_to_string[left.kind], ek_to_string[right.kind])
 				}
 			case bo_or:
@@ -63,6 +67,25 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 }
 
 func cmpIntegerToInteger(left int64, op binary_operator_t, right int64) (bool, error) {
+	switch op {
+	case bo_eq:
+		return left == right, nil
+	case bo_ne:
+		return left != right, nil
+	case bo_gt:
+		return left > right, nil
+	case bo_lt:
+		return left < right, nil
+	case bo_gte:
+		return left >= right, nil
+	case bo_lte:
+		return left <= right, nil
+	}
+
+	return false, fmt.Errorf("comparison operator not implemented yet")
+}
+
+func cmpFloatToFloat(left float64, op binary_operator_t, right float64) (bool, error) {
 	switch op {
 	case bo_eq:
 		return left == right, nil

--- a/eval.go
+++ b/eval.go
@@ -1,0 +1,55 @@
+package quang
+
+import "fmt"
+
+func evaluateExpression(expr *expression_t) (bool, error) {
+	switch expr.kind {
+	case ek_binary:
+		{
+			op := expr.binary.operator
+			left := expr.binary.left
+			right := expr.binary.right
+
+			switch op {
+			case bo_or:
+				{
+					leftValue, err := evaluateExpression(left)
+
+					if err != nil {
+						return false, err
+					}
+
+					rightValue, err := evaluateExpression(right)
+
+					if err != nil {
+						return false, err
+					}
+
+					return leftValue || rightValue, nil
+				}
+			case bo_and:
+				{
+					leftValue, err := evaluateExpression(left)
+
+					if err != nil {
+						return false, err
+					}
+
+					rightValue, err := evaluateExpression(right)
+
+					if err != nil {
+						return false, err
+					}
+
+					return leftValue && rightValue, nil
+				}
+			}
+		}
+	case ek_bool:
+		{
+			return expr.bool, nil
+		}
+	}
+
+	return false, fmt.Errorf("error: could not parse such expression")
+}

--- a/eval.go
+++ b/eval.go
@@ -11,6 +11,14 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 			right := expr.binary.right
 
 			switch op {
+			case bo_eq, bo_ne, bo_gt, bo_lt, bo_gte, bo_lte:
+				{
+					if left.kind == ek_integer && right.kind == ek_integer {
+						return cmpIntegerToInteger(left.integer, op, right.integer)
+					}
+
+					return false, fmt.Errorf("cannot equalize types %s and %s", ek_to_string[left.kind], ek_to_string[right.kind])
+				}
 			case bo_or:
 				{
 					leftValue, err := evaluateExpression(left)
@@ -52,4 +60,23 @@ func evaluateExpression(expr *expression_t) (bool, error) {
 	}
 
 	return false, fmt.Errorf("error: could not parse such expression")
+}
+
+func cmpIntegerToInteger(left int64, op binary_operator_t, right int64) (bool, error) {
+	switch op {
+	case bo_eq:
+		return left == right, nil
+	case bo_ne:
+		return left != right, nil
+	case bo_gt:
+		return left > right, nil
+	case bo_lt:
+		return left < right, nil
+	case bo_gte:
+		return left >= right, nil
+	case bo_lte:
+		return left <= right, nil
+	}
+
+	return false, fmt.Errorf("comparison operator not implemented yet")
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,0 +1,48 @@
+package quang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluate(t *testing.T) {
+	tests := map[string]bool{
+		"true or false":       true,
+		"false or true":       true,
+		"true or true":        true,
+		"false or false":      false,
+		"true and false":      false,
+		"false and true":      false,
+		"false and false":     false,
+		"true and true":       true,
+		"true":                true,
+		"false":               false,
+		"(true)":              true,
+		"(true) or (true)":    true,
+		"(true) or true":      true,
+		"true or (true)":      true,
+		"(false) or (false)":  false,
+		"(true) and (true)":   true,
+		"(false) and (false)": false,
+		"(false and true) or ((true and false) or true)": true,
+		"true and false or true":                         true,
+	}
+
+	for test, expected := range tests {
+		l := createLexer(test)
+
+		assert.Nil(t, l.lex())
+
+		p := createParser(l.tokens)
+
+		expr, err := p.parseExpression()
+
+		assert.Nil(t, err)
+
+		result, err := evaluateExpression(expr)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expected, result)
+	}
+}

--- a/eval_test.go
+++ b/eval_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEvaluate(t *testing.T) {
+func TestEvaluatingBooleanExpressions(t *testing.T) {
 	tests := map[string]bool{
 		"true or false":       true,
 		"false or true":       true,
@@ -28,6 +28,59 @@ func TestEvaluate(t *testing.T) {
 		"(false and true) or ((true and false) or true)": true,
 		"true and false or true":                         true,
 	}
+
+	for test, expected := range tests {
+		l := createLexer(test)
+
+		assert.Nil(t, l.lex())
+
+		p := createParser(l.tokens)
+
+		expr, err := p.parseExpression()
+
+		assert.Nil(t, err)
+
+		result, err := evaluateExpression(expr)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expected, result)
+	}
+}
+
+func TestEvaluatingIntegerExpressions(t *testing.T) {
+	// TODO: add support for (<number>) syntax
+	tests := map[string]bool{
+		"1 eq 1":     true,
+		"1 eq 10":    false,
+		"2 eq 1":     false,
+		"(1 eq 1)":   true,
+		"((1 eq 1))": true,
+		"1 ne 1":     false,
+		"1 ne 2":     true,
+		"2 ne 1":     true,
+		"10 gt 5":    true,
+		"10 gt 15":   false,
+		"15 gt 10":   true,
+		"10 gt 10":   false,
+
+		"10 lt 5":  false,
+		"10 lt 15": true,
+		"15 lt 10": false,
+		"10 lt 10": false,
+
+		"10 gte 10": true,
+		"10 gte 11": false,
+		"11 gte 10": true,
+
+		"10 lte 10": true,
+		"10 lte 11": true,
+		"11 lte 10": false,
+		"(true and false) or (1 gte 0 or 10 lte 5)": true,
+	}
+	// TODO: operator bellow should complaing about types
+	/* "reg"
+	"and"
+	"or" */
 
 	for test, expected := range tests {
 		l := createLexer(test)

--- a/eval_test.go
+++ b/eval_test.go
@@ -99,3 +99,56 @@ func TestEvaluatingIntegerExpressions(t *testing.T) {
 		assert.Equal(t, expected, result)
 	}
 }
+
+func TestEvaluatingFloatExpressions(t *testing.T) {
+	// TODO: add support for (<number>) syntax
+	tests := map[string]bool{
+		"1.5 eq 1.5":    true,
+		"1.5 eq 10.309": false,
+		"2. eq 1.9":     false,
+		"(1. eq 1.)":    true,
+		"((1. eq 1.0))": true,
+		"1. ne 1.0001":  true,
+		"1. ne 2.":      true,
+		"2. ne 1.":      true,
+		"10. gt 5.":     true,
+		"10. gt 15.":    false,
+		"15. gt 10.":    true,
+		"10. gt 10.":    false,
+
+		"10. lt 5.":  false,
+		"10. lt 15.": true,
+		"15. lt 10.": false,
+		"10. lt 10.": false,
+
+		"10. gte 10.": true,
+		"10. gte 11.": false,
+		"11. gte 10.": true,
+
+		"10. lte 10.":   true,
+		"10. lte 11.":   true,
+		"(10. lte 11.)": true,
+		"11. lte 10.":   false,
+	}
+	// TODO: operator bellow should complaing about types
+	/* "reg"
+	"and"
+	"or" */
+
+	for test, expected := range tests {
+		l := createLexer(test)
+
+		assert.Nil(t, l.lex())
+
+		p := createParser(l.tokens)
+
+		expr, err := p.parseExpression()
+
+		assert.Nil(t, err)
+
+		result, err := evaluateExpression(expr)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expected, result, "test: %s", test)
+	}
+}

--- a/lexer.go
+++ b/lexer.go
@@ -185,7 +185,7 @@ func (l *lexer_t) lexString() error {
 			}
 
 			switch l.charAhead() {
-			case '\'':
+			case '\'', '\\':
 				l.forward()
 			default:
 				return fmt.Errorf("error: invalid scape sequence at position %d", l.cursor+1)

--- a/parser.go
+++ b/parser.go
@@ -12,6 +12,8 @@ type expression_kind_t int
 type binary_operator_t int
 type data_type_t int
 type atom_t int8
+type integer_t int64
+type float_t float64
 
 type binary_expression_t struct {
 	operator binary_operator_t
@@ -25,8 +27,8 @@ type expression_t struct {
 	symbolName string
 
 	bool    bool
-	float   float64
-	integer int64
+	float   float_t
+	integer integer_t
 	atom    atom_t
 	string  string
 	binary  *binary_expression_t
@@ -36,8 +38,8 @@ type variable_t struct {
 	dtype data_type_t
 
 	bool    bool
-	float   float64
-	integer int64
+	float   float_t
+	integer integer_t
 	atom    atom_t
 	string  string
 }
@@ -81,6 +83,15 @@ const (
 	dtype_bool
 	dtype_nil
 )
+
+var dtype_to_string = map[data_type_t]string{
+	dtype_integer: "integer",
+	dtype_float:   "float",
+	dtype_string:  "string",
+	dtype_atom:    "atom",
+	dtype_bool:    "bool",
+	dtype_nil:     "nil",
+}
 
 var ek_to_string = map[expression_kind_t]string{
 	ek_nil:         "nil",
@@ -214,7 +225,7 @@ func (p *parser_t) parsePrimary() (*expression_t, error) {
 			return &expression_t{
 				kind:       ek_integer,
 				symbolName: "",
-				integer:    integer,
+				integer:    integer_t(integer),
 			}, nil
 		}
 	case tk_float:
@@ -228,7 +239,7 @@ func (p *parser_t) parsePrimary() (*expression_t, error) {
 			return &expression_t{
 				kind:       ek_float,
 				symbolName: "",
-				float:      float,
+				float:      float_t(float),
 			}, nil
 		}
 	case tk_true_keyword, tk_false_keyword:

--- a/parser.go
+++ b/parser.go
@@ -94,6 +94,18 @@ var ek_to_string = map[expression_kind_t]string{
 	ek_lazy_symbol: "lazy_symbol",
 }
 
+var bo_to_string = map[binary_operator_t]string{
+	bo_eq:  "eq",
+	bo_ne:  "ne",
+	bo_gt:  "gt",
+	bo_lt:  "lt",
+	bo_gte: "gte",
+	bo_lte: "lte",
+	bo_reg: "reg",
+	bo_and: "and",
+	bo_or:  "or",
+}
+
 func lexerTokenKindToBinaryOperator(kind token_kind_t) binary_operator_t {
 	switch kind {
 	case tk_reg_keyword:
@@ -159,7 +171,7 @@ func unescapeString(s string) string {
 		i++
 	}
 
-	return string(bytes[:size+1])
+	return string(bytes[:size])
 }
 
 func createParser(tokens []token_t) parser_t {

--- a/parser.go
+++ b/parser.go
@@ -1,5 +1,8 @@
 package quang
 
+// TODO: "expect" a token, if it's the wrong one, inform the user.
+// TODO: categorize errors like: syntax error, logical error, ...
+
 import (
 	"fmt"
 	"strconv"
@@ -275,8 +278,8 @@ func (p *parser_t) parseComparison() (*expression_t, error) {
 				},
 			}, nil
 		}
-  case tk_or_keyword, tk_and_keyword:
-    return left, nil
+	case tk_or_keyword, tk_and_keyword, tk_close_paren:
+		return left, nil
 	}
 
 	return nil, fmt.Errorf("error: expected comparison operator after expression but got \"%s\"", current.value)

--- a/parser.go
+++ b/parser.go
@@ -256,7 +256,6 @@ func (p *parser_t) parseComparison() (*expression_t, error) {
 	current := p.token()
 
 	switch current.kind {
-
 	case tk_eq_keyword, tk_ne_keyword, tk_gt_keyword, tk_lt_keyword, tk_gte_keyword, tk_lte_keyword, tk_reg_keyword:
 		{
 			p.forward()
@@ -276,6 +275,8 @@ func (p *parser_t) parseComparison() (*expression_t, error) {
 				},
 			}, nil
 		}
+  case tk_or_keyword, tk_and_keyword:
+    return left, nil
 	}
 
 	return nil, fmt.Errorf("error: expected comparison operator after expression but got \"%s\"", current.value)

--- a/parser.go
+++ b/parser.go
@@ -82,6 +82,18 @@ const (
 	dtype_nil
 )
 
+var ek_to_string = map[expression_kind_t]string{
+	ek_nil:         "nil",
+	ek_integer:     "integer",
+	ek_float:       "float",
+	ek_string:      "string",
+	ek_atom:        "atom",
+	ek_bool:        "bool",
+	ek_binary:      "binary",
+	ek_lazy_atom:   "lazy_atom",
+	ek_lazy_symbol: "lazy_symbol",
+}
+
 func lexerTokenKindToBinaryOperator(kind token_kind_t) binary_operator_t {
 	switch kind {
 	case tk_reg_keyword:

--- a/parser.go
+++ b/parser.go
@@ -2,7 +2,6 @@ package quang
 
 // TODO: "expect" a token, if it's the wrong one, inform the user.
 // TODO: categorize errors like: syntax error, logical error, ...
-
 import (
 	"fmt"
 	"strconv"
@@ -10,10 +9,9 @@ import (
 
 type expression_kind_t int
 type binary_operator_t int
-type data_type_t int
-type atom_t int8
-type integer_t int64
-type float_t float64
+type AtomType int8
+type IntegerType int64
+type FloatType float64
 
 type binary_expression_t struct {
 	operator binary_operator_t
@@ -27,21 +25,11 @@ type expression_t struct {
 	symbolName string
 
 	bool    bool
-	float   float_t
-	integer integer_t
-	atom    atom_t
+	float   FloatType
+	integer IntegerType
+	atom    AtomType
 	string  string
 	binary  *binary_expression_t
-}
-
-type variable_t struct {
-	dtype data_type_t
-
-	bool    bool
-	float   float_t
-	integer integer_t
-	atom    atom_t
-	string  string
 }
 
 type parser_t struct {
@@ -74,24 +62,6 @@ const (
 	bo_and
 	bo_or
 )
-
-const (
-	dtype_integer data_type_t = iota
-	dtype_float
-	dtype_string
-	dtype_atom
-	dtype_bool
-	dtype_nil
-)
-
-var dtype_to_string = map[data_type_t]string{
-	dtype_integer: "integer",
-	dtype_float:   "float",
-	dtype_string:  "string",
-	dtype_atom:    "atom",
-	dtype_bool:    "bool",
-	dtype_nil:     "nil",
-}
 
 var ek_to_string = map[expression_kind_t]string{
 	ek_nil:         "nil",
@@ -225,7 +195,7 @@ func (p *parser_t) parsePrimary() (*expression_t, error) {
 			return &expression_t{
 				kind:       ek_integer,
 				symbolName: "",
-				integer:    integer_t(integer),
+				integer:    IntegerType(integer),
 			}, nil
 		}
 	case tk_float:
@@ -239,7 +209,7 @@ func (p *parser_t) parsePrimary() (*expression_t, error) {
 			return &expression_t{
 				kind:       ek_float,
 				symbolName: "",
-				float:      float_t(float),
+				float:      FloatType(float),
 			}, nil
 		}
 	case tk_true_keyword, tk_false_keyword:

--- a/parser_test.go
+++ b/parser_test.go
@@ -73,27 +73,27 @@ func TestParseExpression(t *testing.T) {
 	assert.NotNil(t, expr)
 	assert.Nil(t, err)
 
-  tests := []string{
-    "true or true",
-    "true or false",
-    "false or true",
-    "false or false",
-    "true and true",
-    "true and false",
-    "false and true",
-    "false and false",
-  }
+	tests := []string{
+		"true or true",
+		"true or false",
+		"false or true",
+		"false or false",
+		"true and true",
+		"true and false",
+		"false and true",
+		"false and false",
+	}
 
-  for _, test := range tests {
-    l := createLexer(test)
-    err := l.lex()
+	for _, test := range tests {
+		l := createLexer(test)
+		err := l.lex()
 
-    assert.Nil(t, err)
+		assert.Nil(t, err)
 
-    p := createParser(l.tokens)
-    expr, err := p.parseExpression()
+		p := createParser(l.tokens)
+		expr, err := p.parseExpression()
 
-    assert.NotNil(t, expr)
-    assert.Nil(t, err)
-  }
+		assert.NotNil(t, expr)
+		assert.Nil(t, err)
+	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -72,4 +72,28 @@ func TestParseExpression(t *testing.T) {
 
 	assert.NotNil(t, expr)
 	assert.Nil(t, err)
+
+  tests := []string{
+    "true or true",
+    "true or false",
+    "false or true",
+    "false or false",
+    "true and true",
+    "true and false",
+    "false and true",
+    "false and false",
+  }
+
+  for _, test := range tests {
+    l := createLexer(test)
+    err := l.lex()
+
+    assert.Nil(t, err)
+
+    p := createParser(l.tokens)
+    expr, err := p.parseExpression()
+
+    assert.NotNil(t, expr)
+    assert.Nil(t, err)
+  }
 }

--- a/quang.go
+++ b/quang.go
@@ -1,0 +1,117 @@
+package quang
+
+type Quang struct {
+	evaluator evaluator_t
+}
+
+// Init the whole language. `query` is the expression provided by
+// the user, for example: `size gt 0` which will be evaluated later.
+func Init(query string) (*Quang, error) {
+	l := createLexer(query)
+
+	if err := l.lex(); err != nil {
+		return nil, err
+	}
+
+	p := createParser(l.tokens)
+
+	expr, err := p.parseExpression()
+
+	if err != nil {
+		return nil, err
+	}
+
+	evaluator := createEvaluator(expr)
+
+	return &Quang{
+		evaluator: evaluator,
+	}, nil
+}
+
+// Build the set of available atoms.
+// [You only need to do this once]
+// Atoms works just like enums. You can say that an atom ":get" is 0
+// So, everytime the user types ":get" in the query, i'll be substituted by 0,
+// That way you make it easier to the user by specify a variable "kind", instead of typing 0, he types :get
+func (q *Quang) SetupAtoms(atoms map[string]AtomType) *Quang {
+	for key, value := range atoms {
+		q.SetupAtom(key, value)
+	}
+
+	return q
+}
+
+// Build the set of available atoms.
+// [You only need to do this once]
+// Atoms works just like enums. You can say that an atom ":get" is 0
+// So, everytime the user types ":get" in the query, i'll be substituted by 0,
+// That way you make it easier to the user by specify a variable "kind", instead of typing 0, he types :get
+func (q *Quang) SetupAtom(name string, value AtomType) *Quang {
+	q.evaluator.setAtomValue(name, value)
+
+	return q
+}
+
+// For each evaluation, you can provide different variable values.
+// If, for example you want to do a query over a bunch of logs the user
+// will provide the query, for example filtering by a specific user agent pattern
+// then, for each log row, you can update the "agent" variable value to the current log row user agent
+// so the, when the language lazy evaluate the "agent" variable the query will be applied to the current
+// log row successfully
+func (q *Quang) AddStringVar(name, value string) *Quang {
+	q.evaluator.addStringVar(name, value)
+
+	return q
+}
+
+// For each evaluation, you can provide different variable values.
+// If, for example you want to do a query over a bunch of logs the user
+// will provide the query, for example filtering by a specific user agent pattern
+// then, for each log row, you can update the "agent" variable value to the current log row user agent
+// so the, when the language lazy evaluate the "agent" variable the query will be applied to the current
+// log row successfully
+func (q *Quang) AddIntegerVar(name string, value IntegerType) *Quang {
+	q.evaluator.addIntegerVar(name, value)
+
+	return q
+}
+
+// For each evaluation, you can provide different variable values.
+// If, for example you want to do a query over a bunch of logs the user
+// will provide the query, for example filtering by a specific user agent pattern
+// then, for each log row, you can update the "agent" variable value to the current log row user agent
+// so the, when the language lazy evaluate the "agent" variable the query will be applied to the current
+// log row successfully
+func (q *Quang) AddFloatVar(name string, value FloatType) *Quang {
+	q.evaluator.addFloatVar(name, value)
+
+	return q
+}
+
+// For each evaluation, you can provide different variable values.
+// If, for example you want to do a query over a bunch of logs the user
+// will provide the query, for example filtering by a specific user agent pattern
+// then, for each log row, you can update the "agent" variable value to the current log row user agent
+// so the, when the language lazy evaluate the "agent" variable the query will be applied to the current
+// log row successfully
+func (q *Quang) AddBoolVar(name string, value bool) *Quang {
+	q.evaluator.addBoolVar(name, value)
+
+	return q
+}
+
+// For each evaluation, you can provide different variable values.
+// If, for example you want to do a query over a bunch of logs the user
+// will provide the query, for example filtering by a specific user agent pattern
+// then, for each log row, you can update the "agent" variable value to the current log row user agent
+// so the, when the language lazy evaluate the "agent" variable the query will be applied to the current
+// log row successfully
+func (q *Quang) AddAtomVar(name string, value AtomType) *Quang {
+	q.evaluator.addAtomVar(name, value)
+
+	return q
+}
+
+func (q Quang) Eval() (bool, error) {
+	return q.evaluator.eval()
+}

--- a/quang_test.go
+++ b/quang_test.go
@@ -1,0 +1,65 @@
+package quang_test
+
+import (
+	"testing"
+
+	"github.com/marcos-venicius/quang"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApi(t *testing.T) {
+	q, err := quang.Init("size gt 0 and method eq :get and status eq 200")
+
+	atoms := map[string]quang.AtomType{
+		":get": 0,
+	}
+
+	q.SetupAtoms(atoms)
+
+	assert.Nil(t, err)
+
+	type test_case_t struct {
+		size   quang.IntegerType
+		status quang.IntegerType
+		method quang.AtomType
+		result bool
+	}
+
+	tests := []test_case_t{
+		{
+			size:   0,
+			method: atoms[":get"],
+			status: 200,
+			result: false,
+		},
+		{
+			size:   1,
+			method: atoms[":get"],
+			status: 200,
+			result: true,
+		},
+		{
+			size:   1,
+			method: 1,
+			status: 200,
+			result: false,
+		},
+		{
+			size:   1,
+			method: atoms[":get"],
+			status: 204,
+			result: false,
+		},
+	}
+
+	for _, test := range tests {
+		q.AddAtomVar("method", test.method).
+			AddIntegerVar("size", test.size).
+			AddIntegerVar("status", test.status)
+
+		r, err := q.Eval()
+
+		assert.Nil(t, err)
+		assert.Equal(t, test.result, r)
+	}
+}


### PR DESCRIPTION
> [!WARNING]
> **Nil is not handled yet**



## Api and language details

Does not matter what kind of query you provide as input to the evaluator, it will always return `true` or `false`. If the query is empty, it will always return `true`.

**Data Types**

| name     | supported | format        | description                                                                   |
| -------- | --------- | ------------- | ----------------------------------------------------------------------------- |
| Integers | yes       | `[0-9]+`      | golang 64bit signed integers                                                  |
| Atoms    | yes       | `:[a-zA-Z_]+` | it works like enumerators                                                     |
| String   | yes       | `'.*'`        | you can scape string with `\'`                                                |
| Boolean  | yes       | `true\|false` |                                                                               |
| Nil      | yes       | `nil`         | represents all kinds of empty values ("", nil) (zero is not considered empty) |
| Floats   | yes       | `\d+\.\d*`    | golang 64bit floats                                                           |

**Keywords**

| name     | description   | usage            |
| -------- | ------------- | ---------------- |
| and      | logical and   | `true and true`  |
| or       | logical or    | `true or false`  |
| nil      | null value    | `name eq nil`    |
| true     | boolean true  | `alive eq true`  |
| false    | boolean false | `alive eq false` |

**Operators**

| name     | description                                                                                        | example                 |
| -------- | -------------------------------------------------------------------------------------------------- | ----------------------- |
| eq       | check if `a` is equal to `b`. strict types. (Integers, Strings, Booleans, Nils, Floats, Atoms)     | `a eq b`                |
| ne       | check if `a` is not equal to `b`. strict types. (Integers, Strings, Booleans, Nils, Floats, Atoms) | `a ne b`                |
| lt       | check if `a` is less than `b`. strict types. (Integers, Strings)                                   | `a lt b`                |
| gt       | check if `a` is greater than `b`. strict types. (Integers, Strings)                                | `a gt b`                |
| lte      | check if `a` is less than or equal to `b`. strict types. (Integers, Strings)                       | `a lte b`               |
| gte      | check if `a` is greater than or equal to `b`. strict types. (Integers, Strings)                    | `a gte b`               |
| reg      | check if `a` matches pattern `b`. `b` accepts valid regex. `a` should be a string                  | `a reg b`               |

**Basic syntax**

Pretend we have a list of computers that have the following properties:

- Identifier
- Running
- Cors

So, we could query something like:

```elixir
(running eq true and cors gte 4 and cors lte 10) or (running eq false and identifier reg 'ML-\d+') or identifier eq nil
```
